### PR TITLE
chore: update NuGet packages and migrate to xunit.v3

### DIFF
--- a/Tharga.Fortnox.Tests/Tharga.Fortnox.Tests.csproj
+++ b/Tharga.Fortnox.Tests/Tharga.Fortnox.Tests.csproj
@@ -8,19 +8,19 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.6" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
-    <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
+    <PackageReference Include="xunit.v3" Version="3.2.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/Tharga.Fortnox/Tharga.Fortnox.csproj
+++ b/Tharga.Fortnox/Tharga.Fortnox.csproj
@@ -29,8 +29,8 @@
 	</ItemGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.6" />
-		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.6" />
+		<PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="10.0.8" />
+		<PackageReference Include="Microsoft.Extensions.Http" Version="10.0.8" />
 	</ItemGroup>
 
 </Project>


### PR DESCRIPTION
## Summary
- Migrate test project from `xunit` 2.9.3 to `xunit.v3` 3.2.2
- Bump `coverlet.collector` 8.0.1 → 10.0.0, `Microsoft.NET.Test.Sdk` 18.4.0 → 18.5.1
- Bump `Microsoft.Extensions.*` 10.0.6 → 10.0.8 (both lib and test project)

## Test plan
- [x] `dotnet build -c Release` — clean (0 warnings)
- [x] `dotnet test -c Release` — 66/66 pass on net10.0
- [ ] CI build + security + CodeQL pass
- [ ] Prerelease published to NuGet