### PR TITLE
chore: update NuGet test packages

### DIFF
--- a/Tharga.Fortnox.Tests/Tharga.Fortnox.Tests.csproj
+++ b/Tharga.Fortnox.Tests/Tharga.Fortnox.Tests.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="10.0.0">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.Configuration" Version="10.0.8" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.5.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="NSubstitute" Version="5.3.0" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
## Summary
- `coverlet.collector` 10.0.0 → 10.0.1
- `Microsoft.NET.Test.Sdk` 18.5.1 → 18.6.0

Library project (`Tharga.Fortnox`) has no updates available.

## Test plan
- [x] `dotnet build -c Release` — clean (0 warnings)
- [x] `dotnet test -c Release` — 66/66 pass on net10.0
- [ ] CI build + security + CodeQL pass
- [ ] Prerelease published to NuGet