### PR TITLE
chore: move PackageIconUrl to thargelion.net/assets

### DIFF
--- a/Tharga.Fortnox/Tharga.Fortnox.csproj
+++ b/Tharga.Fortnox/Tharga.Fortnox.csproj
@@ -7,7 +7,7 @@
 		<Company>Thargelion AB</Company>
 		<Product>Tharga Fortnox</Product>
 		<Description>Handling of Fortnox authentication keys.</Description>
-		<PackageIconUrl>http://thargelion.se/wp-content/uploads/2019/11/Thargelion-White-Icon-150.png</PackageIconUrl>
+		<PackageIconUrl>https://thargelion.net/assets/component-fortnox.png</PackageIconUrl>
 		<GenerateDocumentationFile>True</GenerateDocumentationFile>
 		<PackageReadmeFile>README.md</PackageReadmeFile>
 		<PackageProjectUrl>https://github.com/Tharga/Fortnox</PackageProjectUrl>


### PR DESCRIPTION
## Summary
- Replace `<PackageIconUrl>http://thargelion.se/wp-content/uploads/2019/11/Thargelion-White-Icon-150.png</PackageIconUrl>` with `https://thargelion.net/assets/component-fortnox.png`
- Also drops `http://` for `https://`

Resolves the "Move PackageIconUrl to thargelion.net/assets" request for Tharga.Fortnox. Patch release will pick up the new metadata on master merge.

## Test plan
- [x] `curl -I https://thargelion.net/assets/component-fortnox.png` returns 200 (verified)
- [x] `dotnet build -c Release` — clean
- [ ] CI build + security + CodeQL pass
- [ ] Prerelease published, then stable on master merge