### PR TITLE
docs: link to http://fortnox.tharga.net while HTTPS is pending

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![License](https://img.shields.io/badge/license-MIT-blue.svg)](LICENSE)
 [![GitHub repo Issues](https://img.shields.io/github/issues/Tharga/Fortnox?style=flat&logo=github&logoColor=red&label=Issues)](https://github.com/Tharga/Fortnox/issues?q=is%3Aopen)
 
-**Docs:** [fortnox.tharga.net](https://fortnox.tharga.net) — guides, API reference, and the connection-flow walkthrough.
+**Docs:** [fortnox.tharga.net](http://fortnox.tharga.net) — guides, API reference, and the connection-flow walkthrough.
 
 ## Testing
 

--- a/Tharga.Fortnox/README.md
+++ b/Tharga.Fortnox/README.md
@@ -21,6 +21,6 @@ builder.Services.AddThargaFortnox(o =>
 
 ## Documentation
 
-Full guides, the connection-flow walkthrough, scopes reference, and API docs: [fortnox.tharga.net](https://fortnox.tharga.net).
+Full guides, the connection-flow walkthrough, scopes reference, and API docs: [fortnox.tharga.net](http://fortnox.tharga.net).
 
 [![GitHub repo](https://img.shields.io/github/repo-size/Tharga/Fortnox?style=flat&logo=github&logoColor=red&label=Repo)](https://github.com/Tharga/Fortnox)


### PR DESCRIPTION
## Summary
Switch docs site links from `https://` to `http://` until HTTPS is enforced on GitHub Pages (Let's Encrypt cert hasn't been issued yet; only HTTP responds today).

- Root README — "Docs:" link
- Packed README (`Tharga.Fortnox/README.md`) — Documentation section link

When HTTPS is enabled in repo Settings → Pages → "Enforce HTTPS" and the cert is provisioned, this should be reverted to `https://`.

## Test plan
- [x] `curl -sIL http://fortnox.tharga.net` returns 200
- [ ] Verify the README renders the HTTP link correctly on GitHub and NuGet after release